### PR TITLE
Add {mix,group}.HandleFuncC

### DIFF
--- a/group.go
+++ b/group.go
@@ -93,6 +93,10 @@ func (g *Group) HandleFunc(method, path string, handler http.HandlerFunc) {
 	g.m.HandleFunc(method, g.subPath(path), handler)
 }
 
+func (g *Group) HandleFuncC(method, path string, handler xhandler.HandlerFuncC) {
+	g.m.HandleFuncC(method, g.subPath(path), handler)
+}
+
 func (g *Group) subPath(path string) string {
 	if path[0] != '/' {
 		panic("path must start with a '/'")

--- a/group.go
+++ b/group.go
@@ -93,6 +93,8 @@ func (g *Group) HandleFunc(method, path string, handler http.HandlerFunc) {
 	g.m.HandleFunc(method, g.subPath(path), handler)
 }
 
+// HandleFuncC registers a standard xhandler.HandlerFuncC request handler with
+// the given path and method.
 func (g *Group) HandleFuncC(method, path string, handler xhandler.HandlerFuncC) {
 	g.m.HandleFuncC(method, g.subPath(path), handler)
 }

--- a/group_test.go
+++ b/group_test.go
@@ -74,7 +74,7 @@ func TestGroupAdaptors(t *testing.T) {
 }
 
 func TestRouteGroupAPI(t *testing.T) {
-	var get, head, options, post, put, patch, delete bool
+	var get, head, options, post, put, patch, delete, ctx bool
 
 	mux := New()
 	group := mux.NewGroup("/foo") // creates /foo group
@@ -100,6 +100,9 @@ func TestRouteGroupAPI(t *testing.T) {
 	group.DELETE("/DELETE", xhandler.HandlerFuncC(func(_ context.Context, _ http.ResponseWriter, _ *http.Request) {
 		delete = true
 	}))
+	group.HandleFuncC("GET", "/Context", func(_ context.Context, _ http.ResponseWriter, _ *http.Request) {
+		ctx = true
+	})
 
 	w := new(mockResponseWriter)
 
@@ -130,4 +133,8 @@ func TestRouteGroupAPI(t *testing.T) {
 	r, _ = http.NewRequest("DELETE", "/foo/DELETE", nil)
 	mux.ServeHTTPC(context.Background(), w, r)
 	assert.True(t, delete, "routing /foo/DELETE failed")
+
+	r, _ = http.NewRequest("GET", "/foo/Context", nil)
+	mux.ServeHTTPC(context.Background(), w, r)
+	assert.True(t, ctx, "routing /foo/Context failed")
 }

--- a/mux.go
+++ b/mux.go
@@ -276,11 +276,7 @@ func (mux *Mux) HandleFunc(method, path string, handler http.HandlerFunc) {
 }
 
 func (mux *Mux) HandleFuncC(method, path string, handler xhandler.HandlerFuncC) {
-	mux.HandleC(method, path,
-		xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-			handler(ctx, w, r)
-		}),
-	)
+	mux.HandleC(method, path, xhandler.HandlerFuncC(handler))
 }
 
 func (mux *Mux) recv(ctx context.Context, w http.ResponseWriter, r *http.Request) {

--- a/mux.go
+++ b/mux.go
@@ -275,6 +275,14 @@ func (mux *Mux) HandleFunc(method, path string, handler http.HandlerFunc) {
 	)
 }
 
+func (mux *Mux) HandleFuncC(method, path string, handler xhandler.HandlerFuncC) {
+	mux.HandleC(method, path,
+		xhandler.HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+			handler(ctx, w, r)
+		}),
+	)
+}
+
 func (mux *Mux) recv(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	if rcv := recover(); rcv != nil {
 		mux.PanicHandler(ctx, w, r, rcv)

--- a/mux.go
+++ b/mux.go
@@ -275,6 +275,8 @@ func (mux *Mux) HandleFunc(method, path string, handler http.HandlerFunc) {
 	)
 }
 
+// HandleFuncC registers a standard xhandler.HandlerFuncC request handler with
+// the given path and method.
 func (mux *Mux) HandleFuncC(method, path string, handler xhandler.HandlerFuncC) {
 	mux.HandleC(method, path, xhandler.HandlerFuncC(handler))
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -82,12 +82,15 @@ func TestMux(t *testing.T) {
 func TestMuxAdaptors(t *testing.T) {
 	mux := New()
 
-	var handle, handleFunc bool
+	var handle, handleFunc, handleFuncC bool
 	mux.Handle("GET", "/handle", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handle = true
 	}))
 	mux.HandleFunc("GET", "/handleFunc", func(w http.ResponseWriter, r *http.Request) {
 		handleFunc = true
+	})
+	mux.HandleFuncC("GET", "/handleFuncC", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		handleFuncC = true
 	})
 
 	w := new(mockResponseWriter)
@@ -99,6 +102,11 @@ func TestMuxAdaptors(t *testing.T) {
 	r, _ = http.NewRequest("GET", "/handleFunc", nil)
 	mux.ServeHTTPC(context.Background(), w, r)
 	assert.True(t, handleFunc, "routing failed")
+
+	w = new(mockResponseWriter)
+	r, _ = http.NewRequest("GET", "/handleFuncC", nil)
+	mux.ServeHTTPC(context.Background(), w, r)
+	assert.True(t, handleFuncC, "routing failed")
 }
 
 type handlerStruct struct {


### PR DESCRIPTION
This accepts as argument xhandler.HandlerFuncC, rather then
http.HandlerFunc.
