### PR TITLE
Add TestSetParamContext to sets ParamHolder for testing

### DIFF
--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,8 @@
+package xmux
+
+import "golang.org/x/net/context"
+
+// TestSetParamContext sets ParamHolder to context.Context for testing
+func TestSetParamContext(ctx context.Context, p ParamHolder) context.Context {
+	return context.WithValue(ctx, paramsKey, p)
+}


### PR DESCRIPTION
As discussed in https://github.com/rs/xmux/issues/7, this function is purely for testing, and set `ParamHolder` in `context.Context`.

``` go
func helloWithParam(ctx context.Context, w http.ResponseWriter, r *http.Request) {
    n := xmux.Param(ctx, "name")
    fmt.Fprintf(w, "Hello, %s!", n)
    return
}

func main() {
    m := xmux.New()
    m.GET("/hello/:name", xhandler.HandlerFuncC(helloWithParam))
    if err := http.ListenAndServe(":8888", xhandler.New(context.Background(), m)); err != nil {
        log.Fatal(err)
    }
}
```

``` go
func TestHelloWithParam(t *testing.T) {
    n := "dummyName"
    ps := xmux.ParamHolder{xmux.Parameter{Name: "name", Value: n}}
    ctx := xmux.TestSetParamContext(context.TODO(), ps)
    req, _ := http.NewRequest("GET", "/hello/"+n, nil)
    w := httptest.NewRecorder()
    helloWithParam(ctx, w, req)
    t.Log(w.Body)
}
```
